### PR TITLE
hwangsae-relay-user-command : fix typo (bitrate->bitrates)

### DIFF
--- a/hoppfish/hwangsae-relay-user-command.py
+++ b/hoppfish/hwangsae-relay-user-command.py
@@ -55,7 +55,7 @@ class srt(Resource):
                     width = get_json_value(body, 'width', 0)
                     height = get_json_value(body, 'height', 0)
                     fps = get_json_value(body, 'fps', 0)
-                    bitrate = get_json_value(body, 'bitrate', 0)
+                    bitrate = get_json_value(body, 'bitrates', 0)
                     ret = dbus_interface.Start(edge_id, width, height, fps, bitrate)
                     print("ret:", ret)
                 else:
@@ -74,7 +74,7 @@ class srt(Resource):
                     get_json_value(body, 'width', 0),
                     get_json_value(body, 'height', 0),
                     get_json_value(body, 'fps', 0),
-                    get_json_value(body, 'bitrate', 0)
+                    get_json_value(body, 'bitrates', 0)
                 )
 
                 http_ret = 200


### PR DESCRIPTION
Fix parameter name according to REST API document.