### PR TITLE
hwangsae-relay-user-command : add to handle bitrate(s) both

### DIFF
--- a/hoppfish/hwangsae-relay-user-command.py
+++ b/hoppfish/hwangsae-relay-user-command.py
@@ -56,6 +56,8 @@ class srt(Resource):
                     height = get_json_value(body, 'height', 0)
                     fps = get_json_value(body, 'fps', 0)
                     bitrate = get_json_value(body, 'bitrates', 0)
+                    if (bitrate == 0):
+                        bitrate = get_json_value(body, 'bitrate', 0)
                     ret = dbus_interface.Start(edge_id, width, height, fps, bitrate)
                     print("ret:", ret)
                 else:
@@ -69,12 +71,15 @@ class srt(Resource):
 
                 body = request.get_json()
                 print("body:", str(body))
+                bitrate = get_json_value(body, 'bitrates', 0)
+                if bitrate == 0:
+                    bitrate = get_json_value(body, 'bitrate', 0)
                 dbus_interface.ChangeParameters(
                     edge_id,
                     get_json_value(body, 'width', 0),
                     get_json_value(body, 'height', 0),
                     get_json_value(body, 'fps', 0),
-                    get_json_value(body, 'bitrates', 0)
+                    bitrate
                 )
 
                 http_ret = 200


### PR DESCRIPTION
The document of REST API define parameter name for setting bit-rate is bitrates. It is already released
to 3rd party. We are going to change it bitrates to bitrate, but currently we make it to enable  both cases (bitrate and bitrates) to prevent missing bit-rate setting.